### PR TITLE
introduce a compile_and_test target

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,17 @@ make clone
 Will clone the correct repositories and references and place them such that
 they can be mounted into the docker container.
 
+```
+make compile
+```
+
+Will launch the compilation of `llvmlite`, followed by`Numba` in
+the pre-built docker container.
+
 Finally, the command:
 
 ```
-make compile
+make compile_and_test
 ```
 
 Will launch the compilation and testing of `llvmlite`, followed by`Numba` in

--- a/compile_and_test.sh
+++ b/compile_and_test.sh
@@ -13,6 +13,7 @@ export LLVM_CONFIG=/opt/miniconda/envs/buildenv/bin/llvm-config
 # compiled on a quay.io/pypa/manylinux2014_x86_64 image, we need to clamp the
 # C++ ABI version to 0.
 CXXFLAGS="$CXXFLAGS -D_GLIBCXX_USE_CXX11_ABI=0" $MY_PYTHON setup.py install
+$MY_PYTHON -m llvmlite.tests
 cd ..
 
 # numba
@@ -21,4 +22,5 @@ cd numba
 git checkout $MY_NUMBA_COMMIT
 $MY_PYTHON setup.py build_ext -i && $MY_PYTHON setup.py develop --no-deps
 cd ..
+$MY_PYTHON -m numba.runtests -m 6
 exec bash

--- a/makefile
+++ b/makefile
@@ -8,3 +8,5 @@ clone:
 	./clone.sh py311.conf
 compile:
 	docker run -it -v ${PWD}:/root/hostpwd/ hatchery-bootstrap /root/hostpwd/compile.sh /root/hostpwd/py311.local.conf
+compile_and_test:
+	docker run -it -v ${PWD}:/root/hostpwd/ hatchery-bootstrap /root/hostpwd/compile_and_test.sh /root/hostpwd/py311.local.conf


### PR DESCRIPTION
This allows users to compile llvmlite and Numba w/o also running the test suite.